### PR TITLE
Refactor loaders to JSON and add typed models

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,14 +1,20 @@
 import os
 
 from modules.openai_client import AzureOpenAIClient, OpenAIClient
-from modules.csv_parser import load_categories_from_csv, load_warehouses_from_csv, parse_csv_to_post_data
+from modules.csv_parser import (
+    load_categories_from_json,
+    load_interests_from_json,
+    load_warehouses_from_json,
+    parse_csv_to_post_data,
+)
 from modules.csv_writer import write_post_data_to_csv
 from modules.executor import process_batch_input_data
 
 # --- Configuration ---
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
-CATEGORIES_FILE = os.path.join(CURRENT_DIR, "data/categories.csv")
-WAREHOUSES_FILE = os.path.join(CURRENT_DIR, "data/warehouses.csv")
+CATEGORIES_FILE = os.path.join(CURRENT_DIR, "presets/categories.json")
+INTERESTS_FILE = os.path.join(CURRENT_DIR, "presets/interests.json")
+WAREHOUSES_FILE = os.path.join(CURRENT_DIR, "presets/warehouses.json")
 INPUT_DATA_FILE = os.path.join(CURRENT_DIR, "data/test.csv")
 OUTPUT_POST_DATA_FILE = os.path.join(CURRENT_DIR, "output.csv")
 
@@ -26,10 +32,13 @@ def run_pipeline():
     # 1. Load data from external sources
     try:
         print(f"Loading categories from: {CATEGORIES_FILE}")
-        available_categories = load_categories_from_csv(CATEGORIES_FILE)
+        available_categories = load_categories_from_json(CATEGORIES_FILE)
+
+        print(f"Loading interests from: {INTERESTS_FILE}")
+        interests = load_interests_from_json(INTERESTS_FILE)
 
         print(f"Loading warehouses from: {WAREHOUSES_FILE}")
-        warehouses = load_warehouses_from_csv(WAREHOUSES_FILE)
+        warehouses = load_warehouses_from_json(WAREHOUSES_FILE)
         print(warehouses)
         
         print(f"Loading input data from: {INPUT_DATA_FILE}")

--- a/modules/csv_parser.py
+++ b/modules/csv_parser.py
@@ -1,45 +1,76 @@
-from typing import Optional, List, Tuple, Union, TextIO
+from typing import Optional, List, Union, TextIO
 import csv
+import json
 
-from modules.models import PostData
+from modules.models import PostData, Category, Interest, Warehouse
 from modules.post_data_builder import PostDataBuilder
 
-def load_categories_from_csv(filepath: str) -> List[str]:
-    """Loads categories from a single-column CSV file (one category per line)."""
-    categories: List[str] = []
+def load_categories_from_json(filepath: str) -> List[Category]:
+    """Loads ``Category`` objects from a JSON file."""
+    categories: List[Category] = []
     try:
-        with open(filepath, 'r', encoding='utf-8', newline='') as f:
-            reader = csv.reader(f)
-            for row in reader:
-                if row and row[0].strip(): # Check for non-empty row and cell
-                    categories.append(row[0].strip())
+        with open(filepath, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+            for item in data:
+                if item.get('disabled'):
+                    continue
+                try:
+                    value = int(item.get('value'))
+                except (TypeError, ValueError):
+                    continue
+                categories.append(Category(label=item.get('label', ''), value=value))
         print(f"Successfully loaded {len(categories)} categories from '{filepath}'.")
     except FileNotFoundError:
         print(f"Error: Categories file '{filepath}' not found.")
-        raise # Or return empty list / handle as appropriate
+        raise
     except Exception as e:
         print(f"An error occurred while loading categories from '{filepath}': {e}")
-        raise # Or return empty list / handle as appropriate
+        raise
     return categories
 
-def load_warehouses_from_csv(filepath: str) -> List[Tuple[str,str]]:
-    """Loads warehouses from a CSV file with two columns: 'warehouse_id' and 'region'."""
-    warehouses: List[Tuple[str, str]] = []
+
+def load_interests_from_json(filepath: str) -> List[Interest]:
+    """Loads ``Interest`` objects from a JSON file."""
+    interests: List[Interest] = []
     try:
-        with open(filepath, 'r', encoding='utf-8', newline='') as f:
-            reader = csv.DictReader(f)
-            for row in reader:
-                warehouse_id = row.get('warehouse_id', '').strip()
-                region = row.get('currency', '').strip()
-                if warehouse_id and region:
-                    warehouses.append((warehouse_id, region))
+        with open(filepath, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+            for item in data:
+                if item.get('disabled'):
+                    continue
+                interests.append(Interest(label=item.get('label', ''), value=item.get('value', '')))
+        print(f"Successfully loaded {len(interests)} interests from '{filepath}'.")
+    except FileNotFoundError:
+        print(f"Error: Interests file '{filepath}' not found.")
+        raise
+    except Exception as e:
+        print(f"An error occurred while loading interests from '{filepath}': {e}")
+        raise
+    return interests
+
+def load_warehouses_from_json(filepath: str) -> List[Warehouse]:
+    """Loads ``Warehouse`` objects from a JSON file."""
+    warehouses: List[Warehouse] = []
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+            for item in data:
+                if item.get('disabled'):
+                    continue
+                warehouses.append(
+                    Warehouse(
+                        label=item.get('label', ''),
+                        value=item.get('value', ''),
+                        currency=item.get('currency', '')
+                    )
+                )
         print(f"Successfully loaded {len(warehouses)} warehouses from '{filepath}'.")
     except FileNotFoundError:
         print(f"Error: Warehouses file '{filepath}' not found.")
-        raise # Or return empty list / handle as appropriate
+        raise
     except Exception as e:
         print(f"An error occurred while loading warehouses from '{filepath}': {e}")
-        raise # Or return empty list / handle as appropriate
+        raise
     return warehouses
 
 def parse_csv_to_post_data(file_input: Union[str, TextIO]) -> List[PostDataBuilder]:

--- a/modules/executor.py
+++ b/modules/executor.py
@@ -1,13 +1,13 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
-from modules.models import PostData
+from modules.models import PostData, Category, Warehouse
 from modules.openai_client import OpenAIClient
 from modules.post_generator import generate_post
 
 def process_batch_input_data(
     input_data_list: List[PostData],
-    available_categories: List[str],
-    warehouses: List[Tuple[str, str]],
+    available_categories: List[Category],
+    warehouses: List[Warehouse],
     rates: Dict,
     ai_client: OpenAIClient
 ) -> List[PostData]:

--- a/modules/models.py
+++ b/modules/models.py
@@ -1,6 +1,20 @@
 from dataclasses import dataclass
 from typing import Optional
 
+
+@dataclass
+class Category:
+    """Represents a selectable post category."""
+    label: str
+    value: int
+
+
+@dataclass
+class Interest:
+    """Represents a user's area of interest."""
+    label: str
+    value: str
+
 @dataclass
 class PostData:
     title: str
@@ -27,5 +41,7 @@ class PostData:
 
 @dataclass
 class Warehouse:
-    id: str
+    """Represents a fulfillment warehouse."""
+    label: str
+    value: str
     currency: str


### PR DESCRIPTION
## Summary
- switch preset loaders to JSON sources
- define `Category`, `Interest`, and new `Warehouse` dataclasses
- update pipeline to use dataclasses
- adjust executor and generator for typed categories/warehouses

## Testing
- `pytest -q`
- `python3 -m py_compile modules/models.py modules/csv_parser.py modules/executor.py modules/post_generator.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_685049958b4083229f754b38acd07f45