### PR TITLE
Add category_label field

### DIFF
--- a/modules/csv_parser.py
+++ b/modules/csv_parser.py
@@ -190,6 +190,7 @@ def parse_csv_to_post_data(file_input: Union[str, TextIO]) -> List[PostDataBuild
                     'disable_comment': to_bool(get_cleaned_value('disable_comment')) if get_cleaned_value('disable_comment') is not None else PostData.disable_comment,
                     'team_id': get_cleaned_value('team_id') or PostData.team_id,
                     'category': to_int(get_cleaned_value('category')),
+                    'category_label': get_cleaned_value('category_label') or '',
                     'interest': get_cleaned_value('interest') or '',
                     'payment_method': get_cleaned_value('payment_method'),
                     'service': get_cleaned_value('service') or PostData.service,

--- a/modules/models.py
+++ b/modules/models.py
@@ -29,6 +29,7 @@ class PostData:
     source_currency: str
     item_unit_price: float
     region: str
+    category_label: str = ""
     item_weight: Optional[float] = None
     user: str = "B2kKF5R47K8VpY3ynBh9CB"
     status: str = "draft"

--- a/modules/post_generator.py
+++ b/modules/post_generator.py
@@ -309,6 +309,7 @@ def _finalize_data_from_llm_response(
 
     # Category (convert label to numeric value)
     label_to_value = {c.label: c.value for c in available_bns_categories}
+    value_to_label = {c.value: c.label for c in available_bns_categories}
     values = set(label_to_value.values())
     if original_client_input.category and original_client_input.category in values:
         final_data["category"] = original_client_input.category
@@ -319,6 +320,8 @@ def _finalize_data_from_llm_response(
             "Warning: Client/LLM category invalid or missing. Defaulting from valid list."
         )
         final_data["category"] = next(iter(values))
+
+    final_data["category_label"] = value_to_label.get(final_data["category"], "")
 
     # Interest (convert label to value)
     label_to_interest_value = {i.label: i.value for i in available_interests}

--- a/test/test_csv_parser.py
+++ b/test/test_csv_parser.py
@@ -34,6 +34,7 @@ def test_parse_full_row():
         content="Content A",
         image_url="http://img/a.jpg",
         category=1,
+        category_label="",
         interest="Tech",
         warehouse="WH1",
         item_url="http://a.com",


### PR DESCRIPTION
## Summary
- extend `PostData` with `category_label`
- parse `category_label` from CSV files
- assign the new label in `post_generator._finalize_data_from_llm_response`
- update tests for the new field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68512d3fb408832292f51b6e17f9b875