### PR TITLE
Add incremental CSV writing

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from modules.csv_parser import (
     load_forex_rates_from_json,
     parse_csv_to_post_data,
 )
-from modules.csv_writer import write_post_data_to_csv
+
 from modules.executor import process_batch_input_data
 
 # --- Configuration ---
@@ -65,16 +65,15 @@ def run_pipeline():
         available_interests=interests,
         warehouses=warehouses,
         rates=rates,
-        ai_client=ai_client
+        ai_client=ai_client,
+        output_filepath=OUTPUT_POST_DATA_FILE,
     )
 
-    # 4. Write results to an output file
+    # 4. Inform user where results are written
     if generated_posts:
-        print(f"\nWriting {len(generated_posts)} generated posts to: {OUTPUT_POST_DATA_FILE}")
-        try:
-            write_post_data_to_csv(OUTPUT_POST_DATA_FILE, generated_posts)
-        except Exception as e:
-            print(f"Failed to write output data: {e}")
+        print(
+            f"\nAppended {len(generated_posts)} posts to: {OUTPUT_POST_DATA_FILE}"
+        )
     else:
         print("No posts were generated.")
 

--- a/modules/csv_writer.py
+++ b/modules/csv_writer.py
@@ -2,11 +2,12 @@
 import csv
 from typing import List
 from dataclasses import fields, is_dataclass
+import os
 
 from modules.models import PostData
 
 def write_post_data_to_csv(filepath: str, post_data_list: List[PostData]) -> None:
-    """Writes a list of PostData objects to a CSV file."""
+    """Writes a list of ``PostData`` objects to a CSV file."""
     if not post_data_list:
         raise ValueError("No data to write to CSV.")
 
@@ -17,12 +18,37 @@ def write_post_data_to_csv(filepath: str, post_data_list: List[PostData]) -> Non
         raise TypeError("PostData is not a dataclass or does not have fields defined.")
 
     try:
-        with open(filepath, 'w', encoding='utf-8', newline='') as f:
+        with open(filepath, "w", encoding="utf-8", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
             for post_data_item in post_data_list:
-                row_data = post_data_item.__dict__
-                writer.writerow(row_data)
+                writer.writerow(post_data_item.__dict__)
         print(f"Successfully wrote {len(post_data_list)} items to '{filepath}'.")
     except Exception as e:
-        raise ValueError(f"An error occurred while writing data to '{filepath}': {e}")
+        raise ValueError(
+            f"An error occurred while writing data to '{filepath}': {e}"
+        )
+
+
+def append_post_data_to_csv(filepath: str, post_data: PostData) -> None:
+    """Append a single ``PostData`` entry to ``filepath``.
+
+    The CSV header is written if the file does not already exist.
+    """
+    if is_dataclass(PostData):
+        fieldnames = [f.name for f in fields(PostData)]
+    else:
+        raise TypeError("PostData is not a dataclass or does not have fields defined.")
+
+    file_exists = os.path.isfile(filepath)
+
+    try:
+        with open(filepath, "a", encoding="utf-8", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            if not file_exists:
+                writer.writeheader()
+            writer.writerow(post_data.__dict__)
+    except Exception as e:
+        raise ValueError(
+            f"An error occurred while appending data to '{filepath}': {e}"
+        )

--- a/modules/executor.py
+++ b/modules/executor.py
@@ -6,6 +6,7 @@ from modules.openai_client import OpenAIClient
 from modules.post_generator import generate_post
 from modules.scraper import extract_product_data
 from modules.post_data_builder import PostDataBuilder
+from modules.csv_writer import append_post_data_to_csv
 
 def process_batch_input_data(
     input_data_list: List[PostData],
@@ -13,7 +14,8 @@ def process_batch_input_data(
     available_interests: List[Interest],
     warehouses: List[Warehouse],
     rates: Dict,
-    ai_client: OpenAIClient
+    ai_client: OpenAIClient,
+    output_filepath: str | None = None,
 ) -> List[PostData]:
     """
     Processes a list of ``PostData`` items and returns a list of ``PostData`` results.
@@ -50,6 +52,13 @@ def process_batch_input_data(
                 model="gpt-4.1-mini"
             )
             all_post_data.append(post_data_result)
+            if output_filepath:
+                try:
+                    append_post_data_to_csv(output_filepath, post_data_result)
+                except Exception as write_err:
+                    print(
+                        f"Failed to append result for {input_item.item_url} to '{output_filepath}': {write_err}"
+                    )
             print(f"Successfully processed item: '{input_item.item_url}'")
         except ValueError as ve:
             print(f"ValueError processing item '{input_item.item_url}': {ve}. Skipping this item.")

--- a/test/test_csv_writer.py
+++ b/test/test_csv_writer.py
@@ -1,0 +1,36 @@
+import csv
+from modules.models import PostData
+from modules.csv_writer import append_post_data_to_csv
+
+def create_sample_post(idx: int) -> PostData:
+    return PostData(
+        title=f"Title {idx}",
+        content=f"Content {idx}",
+        image_url="http://img/%d.jpg" % idx,
+        category=idx,
+        interest="interest",
+        warehouse="WH",
+        item_url=f"http://example.com/{idx}",
+        item_name=f"Item {idx}",
+        source_price=idx * 1.0,
+        source_currency="USD",
+        item_unit_price=idx * 1.0,
+        region="US",
+    )
+
+def test_append_post_data_to_csv(tmp_path):
+    file_path = tmp_path / "out.csv"
+    post1 = create_sample_post(1)
+    append_post_data_to_csv(str(file_path), post1)
+    assert file_path.exists()
+    with open(file_path, newline="", encoding="utf-8") as f:
+        reader = list(csv.reader(f))
+    assert len(reader) == 2  # header + 1 row
+
+    post2 = create_sample_post(2)
+    append_post_data_to_csv(str(file_path), post2)
+    with open(file_path, newline="", encoding="utf-8") as f:
+        reader = list(csv.reader(f))
+    assert len(reader) == 3  # header + 2 rows
+    assert reader[1][0] == "Title 1"
+    assert reader[2][0] == "Title 2"


### PR DESCRIPTION
## Summary
- let pipeline append each generated post to CSV
- pass output CSV path to process batch function
- add csv writer helper to append
- test CSV append functionality

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68527f73a1388322b50ffe01bbbb13f9