### PR TITLE
Introduce LLM client interface

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import os
 
-from modules.openai_client import AzureOpenAIClient, OpenAIClient
+from modules.openai_client import AzureOpenAIClient, OpenAIClient, LLMClient
 from modules.csv_parser import (
     load_categories_from_json,
     load_interests_from_json,

--- a/modules/executor.py
+++ b/modules/executor.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 
 from dataclasses import asdict
 from modules.models import PostData, Category, Warehouse, Interest
-from modules.openai_client import OpenAIClient
+from modules.openai_client import LLMClient
 from modules.post_generator import generate_post
 from modules.scraper import extract_product_data
 from modules.post_data_builder import PostDataBuilder
@@ -15,7 +15,7 @@ def process_batch_input_data(
     available_interests: List[Interest],
     warehouses: List[Warehouse],
     rates: Dict,
-    ai_client: OpenAIClient,
+    ai_client: LLMClient,
     output_filepath: str | None = None,
     image_output_folder: str | None = None,
 ) -> List[PostData]:


### PR DESCRIPTION
## Summary
- add `LLMClient` abstract base class
- implement interface in Azure and OpenAI clients
- adjust executor and post generator to accept generic client
- check for web-search capability before calling specialized method
- update base interface to take plain prompt and drop system messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b78140b748322aa7358355c4cc423