### PR TITLE
Move JSON parser to utils and add tests

### DIFF
--- a/modules/openai_client.py
+++ b/modules/openai_client.py
@@ -3,6 +3,7 @@ import json
 from typing import List, Dict, Any, Optional, Union
 
 from dotenv import load_dotenv
+from utils.llm import extract_and_parse_json
 
 load_dotenv()
 
@@ -239,36 +240,6 @@ class OpenAIClient:
             tools=[{ "type": "web_search_preview" }]
         )
 
-def extract_and_parse_json(raw_response_text: Optional[str]) -> Any:
-    """
-    Cleans a raw string response presumed to contain JSON, removing common
-    markdown code fences, and then parses it into a Python object.
-
-    Args:
-        raw_response_text: The raw string response from an external source (e.g., LLM).
-                           Can be None or empty.
-
-    Returns:
-        The parsed JSON object (e.g., dict, list).
-
-    Raises:
-        json.JSONDecodeError: If the string cannot be parsed into JSON after cleaning,
-                              or if the input string (or cleaned string) is empty.
-    """
-    if not raw_response_text:
-        raise json.JSONDecodeError("Input response string is empty or None.", raw_response_text or "", 0)
-
-    clean_json_string = raw_response_text.strip()
-    
-    if clean_json_string.startswith("```json"):
-        clean_json_string = clean_json_string[len("```json"):].strip()
-    if clean_json_string.endswith("```"):
-        clean_json_string = clean_json_string[:-len("```")].strip()
-    
-    if not clean_json_string: # If after stripping markdown, the string is empty
-        raise json.JSONDecodeError("Cleaned JSON string is empty.", raw_response_text, 0)
-        
-    return json.loads(clean_json_string)
 
 if __name__ == "__main__":
     try:

--- a/modules/post_generator.py
+++ b/modules/post_generator.py
@@ -4,7 +4,8 @@ import os
 from typing import Dict, List, Optional, Any, Tuple
 
 from modules.models import PostData, Category, Warehouse, Interest
-from modules.openai_client import OpenAIClient, extract_and_parse_json # Using your client
+from modules.openai_client import OpenAIClient
+from utils.llm import extract_and_parse_json
 from modules.csv_parser import load_forex_rates_from_json
 from utils.currency import convert_price
 

--- a/test/test_utils_llm.py
+++ b/test/test_utils_llm.py
@@ -1,0 +1,28 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import pytest
+from utils.llm import extract_and_parse_json
+
+
+@pytest.mark.parametrize(
+    "input_str, expected",
+    [
+        ("{\"a\": 1}", {"a": 1}),
+        ("```json\n{\"a\": 1}\n```", {"a": 1}),
+    ],
+)
+def test_extract_valid_json(input_str, expected):
+    assert extract_and_parse_json(input_str) == expected
+
+
+@pytest.mark.parametrize(
+    "input_str",
+    [None, "", "not json", "```json\n```"],
+)
+def test_extract_invalid_json(input_str):
+    with pytest.raises(json.JSONDecodeError):
+        extract_and_parse_json(input_str)

--- a/utils/llm.py
+++ b/utils/llm.py
@@ -1,0 +1,36 @@
+import json
+from typing import Any, Optional
+
+
+def extract_and_parse_json(raw_response_text: Optional[str]) -> Any:
+    """Cleans a raw string response presumed to contain JSON and parses it.
+
+    This helper removes surrounding Markdown code fences (e.g. ````json` ... ```)
+    if present, then attempts to parse the remaining string as JSON.
+
+    Args:
+        raw_response_text: The raw string response from an external source. Can
+            be ``None`` or empty.
+
+    Returns:
+        The parsed JSON object such as ``dict`` or ``list``.
+
+    Raises:
+        json.JSONDecodeError: If parsing fails or the cleaned string is empty.
+    """
+    if not raw_response_text:
+        raise json.JSONDecodeError(
+            "Input response string is empty or None.", raw_response_text or "", 0
+        )
+
+    clean_json_string = raw_response_text.strip()
+
+    if clean_json_string.startswith("```json"):
+        clean_json_string = clean_json_string[len("```json"):].strip()
+    if clean_json_string.endswith("```"):
+        clean_json_string = clean_json_string[:-len("```")].strip()
+
+    if not clean_json_string:
+        raise json.JSONDecodeError("Cleaned JSON string is empty.", raw_response_text, 0)
+
+    return json.loads(clean_json_string)


### PR DESCRIPTION
## Summary
- centralize `extract_and_parse_json` into `utils/llm.py`
- update `post_generator` and `openai_client` imports
- add unit tests for the JSON parsing helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b8357efa883229424bb418a1e2bad