### PR TITLE
Add LLMClient base and web search flag

### DIFF
--- a/modules/executor.py
+++ b/modules/executor.py
@@ -2,6 +2,7 @@ from typing import Dict, List
 
 from dataclasses import asdict
 from modules.models import PostData, Category, Warehouse, Interest
+from modules.llm_client import LLMClient
 from modules.openai_client import OpenAIClient
 from modules.post_generator import generate_post
 from modules.scraper import extract_product_data
@@ -15,7 +16,7 @@ def process_batch_input_data(
     available_interests: List[Interest],
     warehouses: List[Warehouse],
     rates: Dict,
-    ai_client: OpenAIClient,
+    ai_client: LLMClient,
     output_filepath: str | None = None,
     image_output_folder: str | None = None,
 ) -> List[PostData]:

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -1,0 +1,23 @@
+from typing import Any, Optional
+
+class LLMClient:
+    """Abstract base class for LLM clients."""
+
+    def get_completion(self, *args: Any, **kwargs: Any) -> Optional[str]:
+        """Return a completion from the model."""
+        raise NotImplementedError
+
+    @property
+    def supports_web_search(self) -> bool:
+        """Whether this client can utilize web search."""
+        return False
+
+    def get_completion_with_search(
+        self,
+        *,
+        prompt: str,
+        model: str,
+        temperature: float | None = 1.0,
+    ) -> Optional[str]:
+        """Return a completion utilizing web search when supported."""
+        raise NotImplementedError

--- a/modules/post_generator.py
+++ b/modules/post_generator.py
@@ -4,6 +4,7 @@ import os
 from typing import Dict, List, Optional, Any, Tuple
 
 from modules.models import PostData, Category, Warehouse, Interest
+from modules.llm_client import LLMClient
 from modules.openai_client import OpenAIClient, extract_and_parse_json # Using your client
 from modules.csv_parser import load_forex_rates_from_json
 from utils.currency import convert_price
@@ -162,12 +163,21 @@ def _build_comprehensive_llm_prompt(
 
 def _invoke_comprehensive_llm(
     user_prompt: str,
-    ai_client: OpenAIClient,
+    ai_client: LLMClient,
     model: str,
     expected_keys: List[str]
 ) -> Optional[Dict[str, Any]]:
     messages = [{"role": "user", "content": user_prompt}]
-    raw_response_str = ai_client.get_completion_with_search(model=model, messages=messages)
+    if ai_client.supports_web_search:
+        raw_response_str = ai_client.get_completion_with_search(
+            prompt=user_prompt,
+            model=model,
+        )
+    else:
+        try:
+            raw_response_str = ai_client.get_completion(model=model, messages=messages)
+        except TypeError:
+            raw_response_str = ai_client.get_completion(user_prompt)
 
     if raw_response_str:
         parsed_json = extract_and_parse_json(raw_response_str)
@@ -296,7 +306,7 @@ def generate_post(
     available_interests: List[Interest],
     valid_warehouses: List[Warehouse],
     currency_conversion_rates: Dict[str, Dict[str, float]],
-    ai_client: OpenAIClient,
+    ai_client: LLMClient,
     model: str
 ) -> PostData:
     print(f"INFO: Starting post generation for URL: {item_data.item_url}, Region: {item_data.region}")

--- a/test/test_llm_client.py
+++ b/test/test_llm_client.py
@@ -1,0 +1,42 @@
+from modules.llm_client import LLMClient
+from modules.openai_client import OpenAIClient, AzureOpenAIClient
+from modules.post_generator import _invoke_comprehensive_llm
+
+class DummySearchClient(LLMClient):
+    def __init__(self):
+        self.called_search = False
+    @property
+    def supports_web_search(self) -> bool:
+        return True
+    def get_completion_with_search(self, *, prompt: str, model: str, temperature: float | None = 1.0):
+        self.called_search = True
+        return '{"a": 1}'
+    def get_completion(self, *args, **kwargs):
+        raise AssertionError("should not call get_completion")
+
+class DummyNoSearchClient(LLMClient):
+    def __init__(self):
+        self.called = False
+    def get_completion(self, *args, **kwargs):
+        self.called = True
+        return '{"a": 1}'
+
+
+def test_supports_web_search_flags():
+    o = OpenAIClient.__new__(OpenAIClient)
+    a = AzureOpenAIClient.__new__(AzureOpenAIClient)
+    assert o.supports_web_search is True
+    assert a.supports_web_search is False
+
+
+def test_invoke_comprehensive_llm_respects_flag():
+    search_client = DummySearchClient()
+    no_search_client = DummyNoSearchClient()
+
+    res1 = _invoke_comprehensive_llm("hi", search_client, "model", ["a"])
+    assert search_client.called_search is True
+    assert res1 == {"a": 1}
+
+    res2 = _invoke_comprehensive_llm("hi", no_search_client, "model", ["a"])
+    assert no_search_client.called is True
+    assert res2 == {"a": 1}


### PR DESCRIPTION
## Summary
- create `LLMClient` base class and move it to its own file
- update `OpenAIClient`/`AzureOpenAIClient` to inherit from `LLMClient`
- add `supports_web_search` flag with search-aware completion methods
- ensure Azure client raises `NotImplementedError` for search
- remove optional `dotenv` import, making it a hard requirement
- add tests checking the search capability flag

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b832a18608322a3913ae1953ff02b