### PR TITLE
Check for web search in post generation

### DIFF
--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -20,3 +20,7 @@ class LLMClient:
     ) -> Tuple[Any, Optional[str]]:
         """Return a tuple of raw API response and extracted text."""
         raise NotImplementedError
+
+    def web_search_occurred(self, response: Any) -> bool:
+        """Whether the given response indicates a web search was performed."""
+        return False

--- a/modules/post_generator.py
+++ b/modules/post_generator.py
@@ -186,11 +186,13 @@ def _invoke_comprehensive_llm(
     ai_client: LLMClient,
     model: str,
     expected_keys: List[str]
-) -> Optional[Dict[str, Any]]:
-    _, raw_response_str = ai_client.get_response(
+
+) -> Tuple[Optional[Dict[str, Any]], Any]:
+    use_search = ai_client.supports_web_search
+    raw_response, raw_response_str = ai_client.get_response(
         prompt=user_prompt,
         model=model,
-        use_search=True,
+        use_search=use_search,
     )
 
     if raw_response_str:
@@ -201,10 +203,10 @@ def _invoke_comprehensive_llm(
             missing_keys = [key for key in expected_keys if key not in parsed_json]
             if missing_keys:
                 print(f"Warning: LLM response missing required keys: {missing_keys}. Raw: {raw_response_str}")
-            return parsed_json
+            return parsed_json, raw_response
         else:
             print(f"Warning: LLM response was not a valid JSON dictionary. Raw: {raw_response_str}")
-    return None
+    return None, raw_response
 
 def _parse_llm_post_fields(
     llm_output: Dict[str, Any],
@@ -364,7 +366,16 @@ def generate_post(
         available_interests,
     )
 
-    llm_response_dict = _invoke_comprehensive_llm(user_prompt, ai_client, model, expected_keys)
+    llm_response_dict, raw_llm_response = _invoke_comprehensive_llm(
+        user_prompt, ai_client, model, expected_keys
+    )
+
+    if ai_client.supports_web_search and hasattr(ai_client, "web_search_occurred"):
+        try:
+            if not ai_client.web_search_occurred(raw_llm_response):
+                raise ValueError("LLM response indicates no web search occurred")
+        except Exception:
+            raise ValueError("LLM response indicates no web search occurred")
 
     if llm_response_dict:
         parsed_fields = _parse_llm_post_fields(

--- a/test/test_llm_client.py
+++ b/test/test_llm_client.py
@@ -55,11 +55,11 @@ def test_invoke_comprehensive_llm_respects_flag():
     search_client = DummySearchClient()
     no_search_client = DummyNoSearchClient()
 
-    res1 = _invoke_comprehensive_llm("hi", search_client, "model", ["a"])
+    res1, raw1 = _invoke_comprehensive_llm("hi", search_client, "model", ["a"])
     assert search_client.called_search is True
     assert res1 == {"a": 1}
 
-    res2 = _invoke_comprehensive_llm("hi", no_search_client, "model", ["a"])
+    res2, raw2 = _invoke_comprehensive_llm("hi", no_search_client, "model", ["a"])
     assert no_search_client.called is True
     assert res2 == {"a": 1}
 
@@ -88,6 +88,6 @@ class DummyFailSearchClient(LLMClient):
 
 def test_invoke_comprehensive_llm_aborts_on_search_failure():
     client = DummyFailSearchClient()
-    res = _invoke_comprehensive_llm("hi", client, "model", ["a"])
+    res, raw = _invoke_comprehensive_llm("hi", client, "model", ["a"])
     assert client.called is True
     assert res is None


### PR DESCRIPTION
## Summary
- expose `web_search_occurred` in `LLMClient`
- track raw responses in `_invoke_comprehensive_llm`
- verify web search occurred before finalizing a post
- adjust unit tests for the new return value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bade01a00832290ff5cd1cbb5227a