### PR TITLE
Rename init and respect search flag

### DIFF
--- a/modules/post_generator.py
+++ b/modules/post_generator.py
@@ -202,7 +202,7 @@ def _invoke_comprehensive_llm(
     raw_response, raw_response_str = ai_client.get_response(
         prompt=user_prompt,
         model=model,
-        use_search=True,
+        use_search=ai_client.supports_web_search,
     )
 
     if raw_response_str:


### PR DESCRIPTION
## Summary
- turn `modules` into a package by renaming `_init_.py` to `__init__.py`
- modify `_invoke_comprehensive_llm` to use `supports_web_search`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bb5d41e588322bc872c15c9546af3