### PR TITLE
Refine LLM prompt

### DIFF
--- a/modules/post_generator.py
+++ b/modules/post_generator.py
@@ -177,9 +177,11 @@ def _build_comprehensive_llm_prompt(
     prompt_lines.append(
         f"The style, tone, and structure for 'title' and 'content' should be closely guided by the master examples "
         f"provided below for the {item_data.region} region. {language_guidance} "
-        "The 'content' should generally have two main sections based on your search: "
-        "1. a product introduction (highlighting key features/benefits), and "
-        "2. a brief summary of user reviews or public sentiment."
+        "Your 'content' must contain two sections in this order:\n"
+        "1. 'Product information' — bullet points in a formal tone describing key details.\n"
+        "   - Include the expiration date if the item is food.\n"
+        "   - Include available sizes if the item is clothing.\n"
+        "2. 'User review summary' — bullet points in a casual tone summarizing user feedback."
     )
     prompt_lines.append(
         f"Here are some master examples for your reference. Learn from their structure, "
@@ -202,7 +204,7 @@ def _invoke_comprehensive_llm(
     raw_response, raw_response_str = ai_client.get_response(
         prompt=user_prompt,
         model=model,
-        use_search=True,
+        use_search=ai_client.supports_web_search,
     )
 
     if raw_response_str:

--- a/test/test_post_generator.py
+++ b/test/test_post_generator.py
@@ -3,7 +3,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from modules.post_generator import _assemble_post_data, CTA_BY_WAREHOUSE
+from modules.post_generator import (
+    _assemble_post_data,
+    _build_comprehensive_llm_prompt,
+    CTA_BY_WAREHOUSE,
+)
 from modules.models import PostData, Category, Interest, Warehouse
 
 
@@ -42,3 +46,16 @@ def test_append_call_to_action():
         rates,
     )
     assert result["content"].endswith(CTA_BY_WAREHOUSE["DEFAULT"])
+
+
+def test_prompt_includes_new_guidelines():
+    parsed, item, cats, ints, whs, rates = _sample_data()
+    # ensure region matches available master examples
+    item.region = "HK"
+
+    prompt, _ = _build_comprehensive_llm_prompt(item, cats, ints)
+
+    assert "Product information" in prompt
+    assert "User review summary" in prompt
+    assert "expiration date" in prompt
+    assert "available sizes" in prompt


### PR DESCRIPTION
## Summary
- refine prompt generation to enforce product info and user review sections
- instruct LLM to mention expiration date for food and sizes for clothing
- respect client search capabilities in `_invoke_comprehensive_llm`
- test new prompt guidelines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bb5b3160883228e664e6b719cff60