### PR TITLE
Add aborted generation CSV logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,7 @@ To run a module on its own: `python3 -m modules/<module>.py`
 
 To run the test suite: `pytest`
 
+Failures during post generation are logged to `aborted.csv` with the item URL,
+region, and reason.
+
 Firecrawl scraper: https://www.firecrawl.dev/playground

--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ FOREX_RATES_FILE = os.path.join(CURRENT_DIR, "presets/forex_rates.json")
 INPUT_DATA_FILE = os.path.join(CURRENT_DIR, "data/test2.csv")
 OUTPUT_POST_DATA_FILE = os.path.join(CURRENT_DIR, "output.csv")
 OUTPUT_IMAGE_FOLDER = os.path.join(CURRENT_DIR, "output_images")
+ABORTED_GENERATIONS_FILE = os.path.join(CURRENT_DIR, "aborted.csv")
 
 def run_pipeline():
     """Main function to run the post generation pipeline."""
@@ -69,6 +70,7 @@ def run_pipeline():
         ai_client=ai_client,
         output_filepath=OUTPUT_POST_DATA_FILE,
         image_output_folder=OUTPUT_IMAGE_FOLDER,
+        aborted_filepath=ABORTED_GENERATIONS_FILE,
     )
 
     # 4. Inform user where results are written

--- a/modules/core/models.py
+++ b/modules/core/models.py
@@ -48,3 +48,10 @@ class Warehouse:
     label: str
     value: str
     currency: str
+
+
+@dataclass
+class AbortedGeneration:
+    item_url: str
+    region: str
+    abort_reason: str

--- a/modules/io/csv_writer.py
+++ b/modules/io/csv_writer.py
@@ -4,7 +4,7 @@ from typing import List
 from dataclasses import fields, is_dataclass
 import os
 
-from modules.core.models import PostData
+from modules.core.models import PostData, AbortedGeneration
 
 def write_post_data_to_csv(filepath: str, post_data_list: List[PostData]) -> None:
     """Writes a list of ``PostData`` objects to a CSV file."""
@@ -48,6 +48,30 @@ def append_post_data_to_csv(filepath: str, post_data: PostData) -> None:
             if not file_exists:
                 writer.writeheader()
             writer.writerow(post_data.__dict__)
+    except Exception as e:
+        raise ValueError(
+            f"An error occurred while appending data to '{filepath}': {e}"
+        )
+
+
+def append_aborted_generation_to_csv(filepath: str, aborted: AbortedGeneration) -> None:
+    """Append a single ``AbortedGeneration`` entry to ``filepath``.
+
+    The CSV header is written if the file does not already exist.
+    """
+    if is_dataclass(AbortedGeneration):
+        fieldnames = [f.name for f in fields(AbortedGeneration)]
+    else:
+        raise TypeError("AbortedGeneration is not a dataclass or does not have fields defined.")
+
+    file_exists = os.path.isfile(filepath)
+
+    try:
+        with open(filepath, "a", encoding="utf-8", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+            if not file_exists:
+                writer.writeheader()
+            writer.writerow(aborted.__dict__)
     except Exception as e:
         raise ValueError(
             f"An error occurred while appending data to '{filepath}': {e}"

--- a/test/test_csv_writer.py
+++ b/test/test_csv_writer.py
@@ -1,6 +1,9 @@
 import csv
-from modules.core.models import PostData
-from modules.io.csv_writer import append_post_data_to_csv
+from modules.core.models import PostData, AbortedGeneration
+from modules.io.csv_writer import (
+    append_post_data_to_csv,
+    append_aborted_generation_to_csv,
+)
 
 def create_sample_post(idx: int) -> PostData:
     return PostData(
@@ -16,6 +19,14 @@ def create_sample_post(idx: int) -> PostData:
         source_currency="USD",
         item_unit_price=idx * 1.0,
         region="US",
+    )
+
+
+def create_sample_aborted(idx: int) -> AbortedGeneration:
+    return AbortedGeneration(
+        item_url=f"http://example.com/{idx}",
+        region="US",
+        abort_reason="oops",
     )
 
 def test_append_post_data_to_csv(tmp_path):
@@ -34,3 +45,21 @@ def test_append_post_data_to_csv(tmp_path):
     assert len(reader) == 3  # header + 2 rows
     assert reader[1][0] == "Title 1"
     assert reader[2][0] == "Title 2"
+
+
+def test_append_aborted_generation_to_csv(tmp_path):
+    file_path = tmp_path / "aborted.csv"
+    abort1 = create_sample_aborted(1)
+    append_aborted_generation_to_csv(str(file_path), abort1)
+    assert file_path.exists()
+    with open(file_path, newline="", encoding="utf-8") as f:
+        reader = list(csv.reader(f))
+    assert len(reader) == 2
+
+    abort2 = create_sample_aborted(2)
+    append_aborted_generation_to_csv(str(file_path), abort2)
+    with open(file_path, newline="", encoding="utf-8") as f:
+        reader = list(csv.reader(f))
+    assert len(reader) == 3
+    assert reader[1][0] == "http://example.com/1"
+    assert reader[2][0] == "http://example.com/2"


### PR DESCRIPTION
## Summary
- log aborted generations via new `AbortedGeneration` model
- support writing aborted generations to CSV
- capture failures in `process_batch_input_data`
- record aborted generations in `app.py`
- note new behaviour in README
- test `append_aborted_generation_to_csv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bf4743ae483228b7df50a605ffb48