### PR TITLE
feat: abort on blocked url

### DIFF
--- a/modules/generation/post_generator.py
+++ b/modules/generation/post_generator.py
@@ -127,13 +127,16 @@ def _build_comprehensive_llm_prompt(
     category_labels = [c.label for c in available_bns_categories]
     interest_labels = [i.label for i in available_interests]
 
-    # Early abort instruction
-    prompt_lines.append(
-        f"If you cannot access '{item_data.item_url}' or any search result, "
-        f"reply only with JSON {{\"{ABORT_FIELD}\": \"{ABORT_REASON}\"}}."
-    )
-
     # --- Step-by-step workflow ---
+    prompt_lines.append(
+        f"1) FIRST, attempt to fetch the Item URL '{item_data.item_url}'.\n"
+        f"   • If the fetch fails for any reason (network error, 404, timeout, whatever), your only output must be exactly:\n"
+        f"     {{\"{ABORT_FIELD}\": \"{ABORT_REASON}\"}}\n"
+        "   • You MUST not do anything else after that."
+    )
+    prompt_lines.append(
+        "\n2) Now, and only now, proceed to the rest of the workflow:"
+    )
     prompt_lines.append(
         "\n--- STEP-BY-STEP WORKFLOW ---"
         "\n1. Cleanup the item name provided by the scraper."

--- a/test/test_post_generator.py
+++ b/test/test_post_generator.py
@@ -6,6 +6,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from modules.generation.post_generator import (
     _assemble_post_data,
     CTA_BY_WAREHOUSE,
+    _build_comprehensive_llm_prompt,
+    ABORT_FIELD,
+    ABORT_REASON,
 )
 from modules.core.models import PostData, Category, Interest, Warehouse
 
@@ -75,3 +78,12 @@ def test_assemble_post_data_raises_on_none_price():
             whs,
             rates,
         )
+
+
+def test_prompt_includes_abort_instruction():
+    parsed, item, cats, ints, whs, rates = _sample_data()
+    item.region = "HK"
+    prompt, _ = _build_comprehensive_llm_prompt(item, cats, ints)
+    assert ABORT_FIELD in prompt
+    assert ABORT_REASON in prompt
+

--- a/test/test_post_generator.py
+++ b/test/test_post_generator.py
@@ -87,3 +87,8 @@ def test_prompt_includes_abort_instruction():
     assert ABORT_FIELD in prompt
     assert ABORT_REASON in prompt
 
+    # abort check should appear before workflow instructions
+    workflow_index = prompt.index("STEP-BY-STEP WORKFLOW")
+    abort_index = prompt.index(ABORT_FIELD)
+    assert abort_index < workflow_index
+


### PR DESCRIPTION
## Summary
- add abort flag instructions for the LLM when page access fails
- surface abort_reason before checking web search
- test prompt includes abort instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c21f8321483228a3832fe2b5a86b7