### PR TITLE
Add conditional weight blurb to CTA

### DIFF
--- a/modules/generation/post_generator.py
+++ b/modules/generation/post_generator.py
@@ -75,12 +75,21 @@ PREFERRED_LANG_BY_REGION: Dict[str, str] = {
 
 # Default call-to-action text. Map keys are warehouse codes for future use.
 CTA_BY_WAREHOUSE: Dict[str, str] = {
-    "DEFAULT": "自己買定搵我哋幫你買都得～（大約xx磅，集運好方便）\n唔識操作？一撳「建立代購訂單」，Buyandship代購即刻幫到你！",
+    "DEFAULT": "自己買定搵我哋幫你買都得～（{weight_blurb}集運好方便）\n唔識操作？一撳「建立代購訂單」，Buyandship代購即刻幫到你！",
 }
 
-def _append_call_to_action(content: str, warehouse_code: str) -> str:
-    """Append a CTA to ``content`` based on ``warehouse_code``."""
-    cta = CTA_BY_WAREHOUSE.get(warehouse_code, CTA_BY_WAREHOUSE["DEFAULT"])
+def _append_call_to_action(
+    content: str, warehouse_code: str, item_weight: Optional[float] = None
+) -> str:
+    """Append a CTA to ``content`` based on ``warehouse_code`` and ``item_weight``."""
+    cta_template = CTA_BY_WAREHOUSE.get(warehouse_code, CTA_BY_WAREHOUSE["DEFAULT"])
+
+    weight_blurb = ""
+    if item_weight:
+        pounds = round(item_weight / 453.59237, 1)
+        weight_blurb = f"大約{pounds}磅，"
+
+    cta = cta_template.format(weight_blurb=weight_blurb)
     content = content.rstrip() if content else ""
     return f"{content}\n\n{cta}" if cta else content
 
@@ -371,7 +380,9 @@ def _assemble_post_data(
 
     # Append CTA to the content based on the final warehouse
     final_data["content"] = _append_call_to_action(
-        final_data.get("content", ""), final_data["warehouse"]
+        final_data.get("content", ""),
+        final_data["warehouse"],
+        final_data.get("item_weight"),
     )
 
     return final_data

--- a/test/test_post_generator.py
+++ b/test/test_post_generator.py
@@ -9,7 +9,7 @@ from modules.generation.post_generator import (
 )
 from modules.core.models import PostData, Category, Interest, Warehouse
 
-def _sample_data():
+def _sample_data(weight=None):
     item = PostData(
         title="",
         content="",
@@ -22,6 +22,7 @@ def _sample_data():
         source_price=1.0,
         source_currency="USD",
         item_unit_price=1.0,
+        item_weight=weight,
         region="US",
     )
     categories = [Category(label="cat", value=1)]
@@ -32,7 +33,7 @@ def _sample_data():
     return parsed, item, categories, interests, warehouses, rates
 
 
-def test_append_call_to_action():
+def test_append_call_to_action_without_weight():
     parsed, item, cats, ints, whs, rates = _sample_data()
     result = _assemble_post_data(
         parsed,
@@ -43,7 +44,23 @@ def test_append_call_to_action():
         whs,
         rates,
     )
-    assert result["content"].endswith(CTA_BY_WAREHOUSE["DEFAULT"])
+    expected_cta = CTA_BY_WAREHOUSE["DEFAULT"].format(weight_blurb="")
+    assert result["content"].endswith(expected_cta)
+
+
+def test_append_call_to_action_with_weight():
+    parsed, item, cats, ints, whs, rates = _sample_data(weight=1000)
+    result = _assemble_post_data(
+        parsed,
+        "WH",
+        item,
+        cats,
+        ints,
+        whs,
+        rates,
+    )
+    expected_cta = CTA_BY_WAREHOUSE["DEFAULT"].format(weight_blurb="大約2.2磅，")
+    assert result["content"].endswith(expected_cta)
 
 def test_assemble_post_data_raises_on_zero_price():
     parsed, item, cats, ints, whs, rates = _sample_data()


### PR DESCRIPTION
## Summary
- allow `CTA_BY_WAREHOUSE` to insert dynamic weight text
- inject converted weight in pounds when appending CTA
- update `_assemble_post_data` and tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d136d0e5c8322aa163a4f6d4b5f80