### PR TITLE
Improve item name guardrail

### DIFF
--- a/modules/generation/post_generator.py
+++ b/modules/generation/post_generator.py
@@ -134,7 +134,9 @@ def _build_comprehensive_llm_prompt(
     # --- Step-by-step workflow ---
     prompt_lines.append(
         "\n--- STEP-BY-STEP WORKFLOW ---"
-        "\n1. Cleanup the item name provided by the scraper."
+        "\n1. Cleanup the item name provided by the scraper. If the value seems to be a broad category "
+        "(e.g. 'Shoes' or 'Electronics') rather than a specific product, use the supplied URL or a quick web "
+        "search to determine the real product name."
         "\n2. Select the most suitable category and interest from the lists above (never create new values)."
         "\n3. Generate region-specific 'title' and 'content' matching the exact structure and tone of the provided examples."
         "\n4. Output a single valid JSON object using the structure below with no commentary or markdown."
@@ -174,6 +176,7 @@ def _build_comprehensive_llm_prompt(
         "- Clean the scraped name by removing marketing phrases, adjectives, year or version numbers."
         " Keep only the brand and product type, no more than 6-8 words."
         " Translate the result into English and save it as `item_name`."
+        " If the provided name is just a category, determine the correct product name using the URL or your search results before cleaning."
     )
 
     # category (MCQ)


### PR DESCRIPTION
## Summary
- instruct LLM to verify if scraped item name is a category and find the real product name
- clarify item_name instructions in prompt

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d2797eb6c832293cf2ddea5414c1f