### PR TITLE
Add brand_name output field

### DIFF
--- a/modules/core/models.py
+++ b/modules/core/models.py
@@ -25,6 +25,7 @@ class PostData:
     warehouse: str
     item_url: str
     item_name: str
+    brand_name: str
     source_price: float
     source_currency: str
     item_unit_price: float

--- a/modules/generation/post_generator.py
+++ b/modules/generation/post_generator.py
@@ -145,9 +145,17 @@ def _build_comprehensive_llm_prompt(
     prompt_lines.append(
         "Your entire response MUST be exactly one JSON object with these keys."
     )
-    output_fields = ["item_name", "category", "interest", "title", "content"]
+    output_fields = [
+        "item_name",
+        "brand_name",
+        "category",
+        "interest",
+        "title",
+        "content",
+    ]
     field_desc = {
         "item_name": '  "item_name": "string"',
+        "brand_name": '  "brand_name": "string"',
         "category": '  "category": "string_from_list"',
         "interest": '  "interest": "string_from_list"',
         "source_currency": '  "source_currency": "3_letter_code_or_\"N/A\""',
@@ -174,6 +182,7 @@ def _build_comprehensive_llm_prompt(
         "- Clean the scraped name by removing marketing phrases, adjectives, year or version numbers."
         " Keep only the brand and product type, no more than 6-8 words."
         " Translate the result into English and save it as `item_name`."
+        " Extract just the brand name and save it separately as `brand_name`."
     )
 
     # category (MCQ)
@@ -261,6 +270,7 @@ def _parse_llm_post_fields(
     """Convert category/interest labels from the LLM into stored values."""
     parsed = {
         "item_name": llm_output.get("item_name"),
+        "brand_name": llm_output.get("brand_name"),
         "title": llm_output.get("title"),
         "content": llm_output.get("content"),
     }
@@ -309,6 +319,7 @@ def _assemble_post_data(
 
     # --- Apply LLM generated / transformed output ---
     final_data["item_name"] = parsed_llm_fields.get("item_name")
+    final_data["brand_name"] = parsed_llm_fields.get("brand_name")
     final_data["title"] = parsed_llm_fields.get("title")
     final_data["content"] = parsed_llm_fields.get("content")
 

--- a/modules/io/csv_parser.py
+++ b/modules/io/csv_parser.py
@@ -197,6 +197,7 @@ def parse_csv_to_post_data(file_input: Union[str, TextIO]) -> List[PostDataBuild
                     'discounted': get_cleaned_value('discounted'),
                     'warehouse': get_cleaned_value('warehouse') or '',
                     'item_name': get_cleaned_value('item_name') or '',
+                    'brand_name': get_cleaned_value('brand_name') or '',
                     'source_price': to_float(get_cleaned_value('source_price')),
                     'source_currency': get_cleaned_value('source_currency') or '',
                     'item_unit_price': to_float(get_cleaned_value('item_unit_price')),

--- a/test/test_csv_parser.py
+++ b/test/test_csv_parser.py
@@ -23,8 +23,8 @@ def test_parse_header_only_csv():
 
 def test_parse_full_row():
     csv_content = (
-        "item_url,region,title,content,image_url,category,interest,warehouse,item_name,source_price,source_currency,item_unit_price,item_weight\n"
-        "http://a.com,US,Title A,Content A,http://img/a.jpg,1,Tech,WH1,Item A,9.99,USD,8.88,1.5"
+        "item_url,region,title,content,image_url,category,interest,warehouse,item_name,brand_name,source_price,source_currency,item_unit_price,item_weight\n"
+        "http://a.com,US,Title A,Content A,http://img/a.jpg,1,Tech,WH1,Item A,BrandA,9.99,USD,8.88,1.5"
     )
     result = parse_csv_to_post_data(io.StringIO(csv_content))
     assert len(result) == 1
@@ -39,6 +39,7 @@ def test_parse_full_row():
         warehouse="WH1",
         item_url="http://a.com",
         item_name="Item A",
+        brand_name="BrandA",
         source_price=9.99,
         source_currency="USD",
         item_unit_price=8.88,
@@ -49,8 +50,8 @@ def test_parse_full_row():
 
 def test_parse_from_file(tmp_path):
     csv_content = (
-        "item_url,region,title,content,image_url,category,interest,warehouse,item_name,source_price,source_currency,item_unit_price,item_weight\n"
-        "http://b.com,CA,Title B,Content B,http://img/b.jpg,2,Food,WH2,Item B,5.5,CAD,5.5,0.3"
+        "item_url,region,title,content,image_url,category,interest,warehouse,item_name,brand_name,source_price,source_currency,item_unit_price,item_weight\n"
+        "http://b.com,CA,Title B,Content B,http://img/b.jpg,2,Food,WH2,Item B,BrandB,5.5,CAD,5.5,0.3"
     )
     file_path = tmp_path / "data.csv"
     file_path.write_text(csv_content)
@@ -64,4 +65,5 @@ def test_parse_from_file(tmp_path):
     assert pd.region == "CA"
     assert pd.source_price == 5.5
     assert pd.source_currency == "CAD"
+    assert pd.brand_name == "BrandB"
 

--- a/test/test_csv_writer.py
+++ b/test/test_csv_writer.py
@@ -15,6 +15,7 @@ def create_sample_post(idx: int) -> PostData:
         warehouse="WH",
         item_url=f"http://example.com/{idx}",
         item_name=f"Item {idx}",
+        brand_name=f"Brand{idx}",
         source_price=idx * 1.0,
         source_currency="USD",
         item_unit_price=idx * 1.0,

--- a/test/test_post_generator.py
+++ b/test/test_post_generator.py
@@ -19,6 +19,7 @@ def _sample_data(weight=None):
         warehouse="",
         item_url="http://example.com",
         item_name="",
+        brand_name="",
         source_price=1.0,
         source_currency="USD",
         item_unit_price=1.0,
@@ -29,7 +30,7 @@ def _sample_data(weight=None):
     interests = [Interest(label="int", value="int")]
     warehouses = [Warehouse(label="w", value="WH", currency="USD")]
     rates = {"USD": {"USD": 1.0}}
-    parsed = {"item_name": "Item", "title": "Title", "content": "Base"}
+    parsed = {"item_name": "Item", "brand_name": "Brand", "title": "Title", "content": "Base"}
     return parsed, item, categories, interests, warehouses, rates
 
 


### PR DESCRIPTION
## Summary
- track brand name in `PostData`
- parse brand from CSV rows
- include brand in prompt outputs and assembled post data
- extend tests for new field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e6037d6388322b68bb0e7db6e1fcc