### PR TITLE
Add CTA country mapping and update CTA logic

### DIFF
--- a/modules/generation/post_generator.py
+++ b/modules/generation/post_generator.py
@@ -75,21 +75,48 @@ PREFERRED_LANG_BY_REGION: Dict[str, str] = {
 
 # Default call-to-action text. Map keys are warehouse codes for future use.
 CTA_BY_WAREHOUSE: Dict[str, str] = {
-    "DEFAULT": "自己買定搵我哋幫你買都得～（{weight_blurb}集運好方便）\n唔識操作？一撳「建立代購訂單」，Buy&Ship代購即刻幫到你！",
+    "DEFAULT": (
+        "香港未必有售 {item_name}？想知道「{item_name} 怎樣買」？"
+        "在{country}網站下單，{weight_blurb}透過 Buy&Ship 運回香港，立即建立代購訂單！"
+    ),
+}
+
+# Mapping of warehouse code to its corresponding country/region name in Chinese
+COUNTRY_BY_WAREHOUSE: Dict[str, str] = {
+    "warehouse-4px-uspdx": "美國",
+    "warehouse-bnsus-la": "美國",
+    "warehouse-bnsca-toronto": "加拿大",
+    "warehouse-bnsuk-ashford": "英國",
+    "warehouse-bnsit-milan": "意大利",
+    "warehouse-qs-osaka": "日本",
+    "warehouse-bnsjp-2": "日本",
+    "warehouse-kas-seoul": "韓國",
+    "warehouse-lht-dongguan": "中國",
+    "warehouse-bns-hk": "香港",
+    "warehouse-bnstw-taipei": "台灣",
+    "warehouse-bnsau-sydney": "澳洲",
+    "warehouse-bnsth-bangkok": "泰國",
+    "warehouse-bnsid-jakarta": "印尼",
 }
 
 def _append_call_to_action(
-    content: str, warehouse_code: str, item_weight: Optional[float] = None
+    content: str,
+    warehouse_code: str,
+    item_name: str,
+    item_weight: Optional[float] = None,
 ) -> str:
     """Append a CTA to ``content`` based on ``warehouse_code`` and ``item_weight``."""
     cta_template = CTA_BY_WAREHOUSE.get(warehouse_code, CTA_BY_WAREHOUSE["DEFAULT"])
+    country = COUNTRY_BY_WAREHOUSE.get(warehouse_code, "")
 
     weight_blurb = ""
     if item_weight:
         pounds = round(item_weight / 453.59237, 2)
         weight_blurb = f"大約{pounds}磅，"
 
-    cta = cta_template.format(weight_blurb=weight_blurb)
+    cta = cta_template.format(
+        weight_blurb=weight_blurb, item_name=item_name, country=country
+    )
     content = content.rstrip() if content else ""
     return f"{content}\n\n{cta}" if cta else content
 
@@ -389,10 +416,11 @@ def _assemble_post_data(
         )
         final_data["interest"] = next(iter(interest_values))
 
-    # Append CTA to the content based on the final warehouse
+    # Append CTA to the content based on the final warehouse and item name
     final_data["content"] = _append_call_to_action(
         final_data.get("content", ""),
         final_data["warehouse"],
+        final_data.get("item_name", ""),
         final_data.get("item_weight"),
     )
 

--- a/test/test_post_generator.py
+++ b/test/test_post_generator.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from modules.generation.post_generator import (
     _assemble_post_data,
     CTA_BY_WAREHOUSE,
+    COUNTRY_BY_WAREHOUSE,
 )
 from modules.core.models import PostData, Category, Interest, Warehouse
 
@@ -28,7 +29,7 @@ def _sample_data(weight=None):
     )
     categories = [Category(label="cat", value=1)]
     interests = [Interest(label="int", value="int")]
-    warehouses = [Warehouse(label="w", value="WH", currency="USD")]
+    warehouses = [Warehouse(label="w", value="warehouse-4px-uspdx", currency="USD")]
     rates = {"USD": {"USD": 1.0}}
     parsed = {"item_name": "Item", "brand_name": "Brand", "title": "Title", "content": "Base"}
     return parsed, item, categories, interests, warehouses, rates
@@ -38,14 +39,18 @@ def test_append_call_to_action_without_weight():
     parsed, item, cats, ints, whs, rates = _sample_data()
     result = _assemble_post_data(
         parsed,
-        "WH",
+        "warehouse-4px-uspdx",
         item,
         cats,
         ints,
         whs,
         rates,
     )
-    expected_cta = CTA_BY_WAREHOUSE["DEFAULT"].format(weight_blurb="")
+    expected_cta = CTA_BY_WAREHOUSE["DEFAULT"].format(
+        weight_blurb="",
+        item_name="Item",
+        country=COUNTRY_BY_WAREHOUSE.get("warehouse-4px-uspdx", ""),
+    )
     assert result["content"].endswith(expected_cta)
 
 
@@ -53,14 +58,18 @@ def test_append_call_to_action_with_weight():
     parsed, item, cats, ints, whs, rates = _sample_data(weight=1000)
     result = _assemble_post_data(
         parsed,
-        "WH",
+        "warehouse-4px-uspdx",
         item,
         cats,
         ints,
         whs,
         rates,
     )
-    expected_cta = CTA_BY_WAREHOUSE["DEFAULT"].format(weight_blurb="大約2.2磅，")
+    expected_cta = CTA_BY_WAREHOUSE["DEFAULT"].format(
+        weight_blurb="大約2.2磅，",
+        item_name="Item",
+        country=COUNTRY_BY_WAREHOUSE.get("warehouse-4px-uspdx", ""),
+    )
     assert result["content"].endswith(expected_cta)
 
 def test_assemble_post_data_raises_on_zero_price():


### PR DESCRIPTION
## Summary
- map warehouse codes to their countries
- tweak the CTA template and function
- pass item name for CTA assembly and update tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864bed453b88322b818d6d6641f83e4